### PR TITLE
Upgrade examples to latest downstream Camel 4.18 versions

### DIFF
--- a/examples/cicd/camel-cicd-exampleapp/pom.xml
+++ b/examples/cicd/camel-cicd-exampleapp/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
         <groovy.version>4.0.11</groovy.version>
 
         <skipITs>true</skipITs>

--- a/examples/ocp/configmaps/camel-quarkus/retrieval/pom.xml
+++ b/examples/ocp/configmaps/camel-quarkus/retrieval/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -115,12 +115,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/examples/ocp/configmaps/camel-spring-boot/retrieval/pom.xml
+++ b/examples/ocp/configmaps/camel-spring-boot/retrieval/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,7 +19,7 @@
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080
         </camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
     <repositories>
@@ -44,15 +44,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/ocp/http-ssl/camel-quarkus/client/pom.xml
+++ b/examples/ocp/http-ssl/camel-quarkus/client/pom.xml
@@ -14,7 +14,7 @@
 		<maven.compiler.release>17</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+		<quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 		<groovy.version>4.0.11</groovy.version>
 
 		<surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/examples/ocp/http-ssl/camel-quarkus/server/pom.xml
+++ b/examples/ocp/http-ssl/camel-quarkus/server/pom.xml
@@ -14,7 +14,7 @@
 		<maven.compiler.release>17</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+		<quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 		<groovy.version>4.0.11</groovy.version>
 
 		<surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/examples/ocp/http-ssl/camel-spring-boot/client/pom.xml
+++ b/examples/ocp/http-ssl/camel-spring-boot/client/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.6</version>
+		<version>3.5.16</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -17,7 +17,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<camel.springboot.kubernetes.image-name>camel-http-ssl-client:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
-		<camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+		<camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
 		<jkube.enricher.jkube-service.name>camel-http-ssl-client</jkube.enricher.jkube-service.name>
 		<jkube.enricher.jkube-controller.name>camel-http-ssl-client</jkube.enricher.jkube-controller.name>
 		<jkube.enricher.jkube-controller.type>Deployment</jkube.enricher.jkube-controller.type>
@@ -45,15 +45,15 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>3.3.6</version>
+				<version>3.5.16</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<!-- Camel BOM -->
 			<dependency>
-				<groupId>org.apache.camel.springboot</groupId>
+				<groupId>com.redhat.camel.springboot.platform</groupId>
 				<artifactId>camel-spring-boot-bom</artifactId>
-				<version>4.8.0.redhat-00022</version>
+				<version>4.18.1.redhat-00029</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/examples/ocp/http-ssl/camel-spring-boot/server/pom.xml
+++ b/examples/ocp/http-ssl/camel-spring-boot/server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.6</version>
+		<version>3.5.16</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -17,7 +17,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<camel.springboot.kubernetes.image-name>camel-http-ssl-server:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
-		<camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+		<camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
 		<jkube.enricher.jkube-service.name>camel-http-ssl-server</jkube.enricher.jkube-service.name>
 		<jkube.enricher.jkube-service.port>8443:8443</jkube.enricher.jkube-service.port>
 		<jkube.enricher.jkube-controller.name>camel-http-ssl-server</jkube.enricher.jkube-controller.name>
@@ -48,15 +48,15 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>3.3.6</version>
+				<version>3.5.16</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<!-- Camel BOM -->
 			<dependency>
-				<groupId>org.apache.camel.springboot</groupId>
+				<groupId>com.redhat.camel.springboot.platform</groupId>
 				<artifactId>camel-spring-boot-bom</artifactId>
-				<version>4.8.0.redhat-00022</version>
+				<version>4.18.1.redhat-00029</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/examples/ocp/kafka-oauth/camel-quarkus/kafka-oauth/pom.xml
+++ b/examples/ocp/kafka-oauth/camel-quarkus/kafka-oauth/pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.15.4.redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.3.1</surefire-plugin.version>
         <kafka-oauth-client.version>0.15.0.redhat-00012</kafka-oauth-client.version>

--- a/examples/ocp/kafka-oauth/camel-spring-boot/kafka-oauth/pom.xml
+++ b/examples/ocp/kafka-oauth/camel-spring-boot/kafka-oauth/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>
-    <spring.boot-version>3.3.10</spring.boot-version>
+    <spring.boot-version>3.5.16</spring.boot-version>
     <surefire.plugin.version>3.5.0</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
     <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-spring-boot-bom</artifactId>
-        <version>4.8.5.redhat-00008</version>
+        <version>4.18.1.redhat-00029</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -130,7 +130,7 @@
       <plugin>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>patch-maven-plugin</artifactId>
-        <version>4.8.5.redhat-00008</version>
+        <version>4.18.1.redhat-00029</version>
         <extensions>true</extensions>
         <configuration>
           <skip>false</skip>
@@ -148,7 +148,7 @@
           <plugin>
             <groupId>org.eclipse.jkube</groupId>
             <artifactId>openshift-maven-plugin</artifactId>
-            <version>1.17.0.redhat-00040</version>
+            <version>1.19.0.redhat-00073</version>
             <executions>
               <execution>
                 <goals>

--- a/examples/ocp/secrets/camel-quarkus/retrieval/pom.xml
+++ b/examples/ocp/secrets/camel-quarkus/retrieval/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -115,12 +115,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/examples/ocp/secrets/camel-spring-boot/retrieval/pom.xml
+++ b/examples/ocp/secrets/camel-spring-boot/retrieval/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,7 +19,7 @@
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080
         </camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
     <repositories>
@@ -44,15 +44,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/aws/camel-spring-boot/retrieval-and-refresh/pom.xml
+++ b/examples/vault/aws/camel-spring-boot/retrieval-and-refresh/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
         <java.version>17</java.version>
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080</camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
      <repositories>
@@ -43,15 +43,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/aws/camel-spring-boot/retrieval/pom.xml
+++ b/examples/vault/aws/camel-spring-boot/retrieval/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
         <java.version>17</java.version>
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080</camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
       <repositories>
@@ -43,15 +43,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/azure/camel-quarkus/retrieval-and-refresh/pom.xml
+++ b/examples/vault/azure/camel-quarkus/retrieval-and-refresh/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -119,12 +119,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/examples/vault/azure/camel-quarkus/retrieval/pom.xml
+++ b/examples/vault/azure/camel-quarkus/retrieval/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -119,12 +119,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/examples/vault/azure/camel-spring-boot/retrieval-and-refresh/pom.xml
+++ b/examples/vault/azure/camel-spring-boot/retrieval-and-refresh/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,7 +19,7 @@
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080
         </camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
     <repositories>
@@ -44,15 +44,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/azure/camel-spring-boot/retrieval/pom.xml
+++ b/examples/vault/azure/camel-spring-boot/retrieval/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,7 +19,7 @@
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080
         </camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
     <repositories>
@@ -44,15 +44,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/external-secrets-operator/camel-quarkus/retrieval-and-refresh/pom.xml
+++ b/examples/vault/external-secrets-operator/camel-quarkus/retrieval-and-refresh/pom.xml
@@ -14,9 +14,9 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.12.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -41,7 +41,21 @@
         </dependencies>
     </dependencyManagement>
 
-
+    <repositories>
+        <repository>
+          <id>MRRC</id>
+          <url>https://maven.repository.redhat.com/ga</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases />
+          <snapshots />
+          <id>MRRCplugin</id>
+          <name>MRRCplugin</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+        </pluginRepository>
+      </pluginRepositories>
 
     <dependencies>
         <dependency>
@@ -99,12 +113,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.7.0</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.7.0</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -115,12 +129,11 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.7.0</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>6.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -130,7 +143,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
         </dependency>
 
         <dependency>

--- a/examples/vault/gcp/camel-quarkus/retrieval-and-refresh/pom.xml
+++ b/examples/vault/gcp/camel-quarkus/retrieval-and-refresh/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -119,12 +119,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/examples/vault/gcp/camel-quarkus/retrieval/pom.xml
+++ b/examples/vault/gcp/camel-quarkus/retrieval/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -119,12 +119,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/examples/vault/gcp/camel-spring-boot/retrieval-and-refresh/pom.xml
+++ b/examples/vault/gcp/camel-spring-boot/retrieval-and-refresh/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,7 +19,7 @@
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080
         </camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
     <repositories>
@@ -44,15 +44,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/gcp/camel-spring-boot/retrieval/pom.xml
+++ b/examples/vault/gcp/camel-spring-boot/retrieval/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,7 +19,7 @@
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080
         </camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
     <repositories>
@@ -44,15 +44,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/hashicorp-vault/camel-quarkus/retrieval/pom.xml
+++ b/examples/vault/hashicorp-vault/camel-quarkus/retrieval/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.2.redhat-00003</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.redhat-00002</quarkus.platform.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
@@ -115,12 +115,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/examples/vault/hashicorp-vault/camel-spring-boot/retrieval/pom.xml
+++ b/examples/vault/hashicorp-vault/camel-spring-boot/retrieval/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
         <java.version>17</java.version>
         <camel.springboot.kubernetes.image-name>sql-to-log:1.0-SNAPSHOT</camel.springboot.kubernetes.image-name>
         <camel.springboot.kubernetes.ports.http.container-port>8080</camel.springboot.kubernetes.ports.http.container-port>
-        <camel.springboot.jkube.version>1.17.0</camel.springboot.jkube.version>
+        <camel.springboot.jkube.version>1.19.0.redhat-00073</camel.springboot.jkube.version>
     </properties>
     
     <repositories>
@@ -43,15 +43,15 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.6</version>
+                <version>3.5.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <!-- Camel BOM -->
             <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
-                <version>4.8.0.redhat-00022</version>
+                <version>4.18.1.redhat-00029</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-utils</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets</artifactId>
-            <version>4.8.0.redhat-00027</version>
+            <version>4.18.1.redhat-00034</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary
- Upgrade all 24 example pom.xml files to the latest Red Hat downstream Camel 4.18 versions
- **Quarkus Platform**: `3.15.x.redhat` → `3.33.2.redhat-00002`
- **Camel Spring Boot BOM**: `4.8.x.redhat` → `4.18.1.redhat-00029` (switched to `com.redhat.camel.springboot.platform` group)
- **Spring Boot**: `3.3.x` → `3.5.16`
- **Camel Kamelets**: `4.7.0`/`4.8.0.redhat-00027` → `4.18.1.redhat-00034`
- **JKube**: `1.17.0`/`1.17.0.redhat-00040` → `1.19.0.redhat-00073`
- **external-secrets-operator**: switched from upstream `io.quarkus.platform:3.12.2` to downstream `com.redhat.quarkus.platform:3.33.2.redhat-00002`, added Red Hat Maven repository, removed hardcoded dependency versions now managed by the BOM

## Test plan
- [ ] Verify Quarkus examples resolve dependencies from Red Hat Maven repository
- [ ] Verify Spring Boot examples resolve dependencies from Red Hat Maven repository
- [ ] Verify external-secrets-operator example builds with downstream BOMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)